### PR TITLE
Add Windows build files

### DIFF
--- a/build_windows.sh
+++ b/build_windows.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+cd `dirname $0`
+
+# Create a virtual environment to run our code
+VENV_NAME="venv"
+PYTHON="$VENV_NAME/Scripts/python"
+
+if ! $PYTHON -m pip install pyinstaller -Uqq; then
+    exit 1
+fi
+
+$PYTHON -m PyInstaller --onefile --hidden-import="googleapiclient" src/main.py
+tar -czvf dist/archive.tar.gz ./dist/main.exe

--- a/setup_windows.sh
+++ b/setup_windows.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+cd `dirname $0`
+
+# Create a virtual environment to run our code
+VENV_NAME="venv"
+PYTHON="$VENV_NAME/Scripts/python"
+ENV_ERROR="This module requires Python >=3.8, pip, and virtualenv to be installed."
+
+if ! python -m venv $VENV_NAME >/dev/null 2>&1; then
+    echo "Failed to create virtualenv."
+    if command -v apt-get >/dev/null; then
+        echo "Detected Debian/Ubuntu, attempting to install python3-venv automatically."
+        SUDO="sudo"
+        if ! command -v $SUDO >/dev/null; then
+            SUDO=""
+        fi
+		if ! apt info python3-venv >/dev/null 2>&1; then
+			echo "Package info not found, trying apt update"
+			$SUDO apt -qq update >/dev/null
+		fi
+        $SUDO apt install -qqy python3-venv >/dev/null 2>&1
+        if ! python3 -m venv $VENV_NAME >/dev/null 2>&1; then
+            echo $ENV_ERROR >&2
+            exit 1
+        fi
+    else
+        echo $ENV_ERROR >&2
+        exit 1
+    fi
+fi
+
+# remove -U if viam-sdk should not be upgraded whenever possible
+# -qq suppresses extraneous output from pip
+echo "Virtualenv found/created. Installing/upgrading Python packages..."
+$PYTHON -m pip install -r requirements.txt -U


### PR DESCRIPTION
Eventually, we'll want to set it up so that the CI can determine the OS and build accordingly.  The first step (at least for now) is having these windows build files somewhere in the repo.  Tested on Windows machine obvs.